### PR TITLE
Org rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,84 +1,84 @@
 # Changelog
 
-## [v0.4.1](https://github.com/UAL-ODIS/redata-commons/tree/v0.4.1) (2021-06-08)
+## [v0.4.1](https://github.com/UAL-RE/redata-commons/tree/v0.4.1) (2021-06-08)
 
 **Implemented enhancements:**
- - redata_request should also provide the requests.Request response [#19](http://github.com/UAL-ODIS/redata-commons/pull/19)
+ - redata_request should also provide the requests.Request response [#19](http://github.com/UAL-RE/redata-commons/pull/19)
 
 **Closed issues:**
- - redata_request should also provide the requests.Request response [#18](http://github.com/UAL-ODIS/redata-commons/issues/18)
+ - redata_request should also provide the requests.Request response [#18](http://github.com/UAL-RE/redata-commons/issues/18)
 
 
-## [v0.4.0](https://github.com/UAL-ODIS/redata-commons/tree/v0.4.0) (2021-05-17)
+## [v0.4.0](https://github.com/UAL-RE/redata-commons/tree/v0.4.0) (2021-05-17)
 
 **Implemented enhancements:**
- - Add issue_requests function to code [#15](http://github.com/UAL-ODIS/redata-commons/pull/15)
+ - Add issue_requests function to code [#15](http://github.com/UAL-RE/redata-commons/pull/15)
 
 **Closed issues:**
- - Add issue_requests function to code [#11](http://github.com/UAL-ODIS/redata-commons/issues/11)
+ - Add issue_requests function to code [#11](http://github.com/UAL-RE/redata-commons/issues/11)
 
 
-## [v0.3.2](https://github.com/UAL-ODIS/redata-commons/tree/v0.3.2) (2021-04-20)
+## [v0.3.2](https://github.com/UAL-RE/redata-commons/tree/v0.3.2) (2021-04-20)
 
 **Fixed bugs:**
- - Bug: LogCommons has hardcoded pieces [#13](http://github.com/UAL-ODIS/redata-commons/issues/13)
+ - Bug: LogCommons has hardcoded pieces [#13](http://github.com/UAL-RE/redata-commons/issues/13)
 
 **Merged pull requests:**
- - Bug: LogCommons has hardcoded pieces [#14](http://github.com/UAL-ODIS/redata-commons/pull/14)
+ - Bug: LogCommons has hardcoded pieces [#14](http://github.com/UAL-RE/redata-commons/pull/14)
 
 
-## [v0.3.1](https://github.com/UAL-ODIS/redata-commons/tree/v0.3.1) (2021-04-14)
-
-**Implemented enhancements:**
- - Update README.md for Sphinx documentation [#12](http://github.com/UAL-ODIS/redata-commons/pull/12)
-
-**Closed issues:**
- - Update README.md for Sphinx documentation [#9](http://github.com/UAL-ODIS/redata-commons/issues/9)
-
-
-## [v0.3.0](https://github.com/UAL-ODIS/redata-commons/tree/v0.3.0) (2021-04-05)
+## [v0.3.1](https://github.com/UAL-RE/redata-commons/tree/v0.3.1) (2021-04-14)
 
 **Implemented enhancements:**
- - Add logger module [#10](http://github.com/UAL-ODIS/redata-commons/pull/10)
+ - Update README.md for Sphinx documentation [#12](http://github.com/UAL-RE/redata-commons/pull/12)
 
 **Closed issues:**
- - Add logger module [#1](http://github.com/UAL-ODIS/redata-commons/issues/1)
+ - Update README.md for Sphinx documentation [#9](http://github.com/UAL-RE/redata-commons/issues/9)
 
 
-## [v0.2.0](https://github.com/UAL-ODIS/redata-commons/tree/v0.2.0) (2021-03-29)
+## [v0.3.0](https://github.com/UAL-RE/redata-commons/tree/v0.3.0) (2021-04-05)
 
 **Implemented enhancements:**
- - Add sphinx documentation and publish to ReadTheDocs [#8](http://github.com/UAL-ODIS/redata-commons/pull/8)
+ - Add logger module [#10](http://github.com/UAL-RE/redata-commons/pull/10)
 
 **Closed issues:**
- - Add sphinx documentation and publish to ReadTheDocs [#5](http://github.com/UAL-ODIS/redata-commons/issues/5)
- - Renaming the repository from redata_commons -> redata-commons [#7](http://github.com/UAL-ODIS/redata-commons/issues/7)
+ - Add logger module [#1](http://github.com/UAL-RE/redata-commons/issues/1)
 
 
-## [v0.1.0](https://github.com/UAL-ODIS/redata-commons/tree/v0.1.0) (2021-03-17)
+## [v0.2.0](https://github.com/UAL-RE/redata-commons/tree/v0.2.0) (2021-03-29)
+
+**Implemented enhancements:**
+ - Add sphinx documentation and publish to ReadTheDocs [#8](http://github.com/UAL-RE/redata-commons/pull/8)
+
+**Closed issues:**
+ - Add sphinx documentation and publish to ReadTheDocs [#5](http://github.com/UAL-RE/redata-commons/issues/5)
+ - Renaming the repository from redata_commons -> redata-commons [#7](http://github.com/UAL-RE/redata-commons/issues/7)
+
+
+## [v0.1.0](https://github.com/UAL-RE/redata-commons/tree/v0.1.0) (2021-03-17)
 
 **Implemented enhancements:**
  - Add `git_info` module, include create release GitHub Actions; Include PyPI
-   publishing GitHub Actions [#4](github.com/UAL-ODIS/redata-commons/pull/4)
+   publishing GitHub Actions [#4](github.com/UAL-RE/redata-commons/pull/4)
 
 **Closed issues:**
- - Add `git_info` module [#2](http://github.com/UAL-ODIS/redata-commons/issues/2)
- - Add create release GitHub Actions [#3](http://github.com/UAL-ODIS/redata-commons/issues/3)
- - Include GitHub Actions for automated PyPI publishing [#6](http://github.com/UAL-ODIS/redata-commons/issues/2)
+ - Add `git_info` module [#2](http://github.com/UAL-RE/redata-commons/issues/2)
+ - Add create release GitHub Actions [#3](http://github.com/UAL-RE/redata-commons/issues/3)
+ - Include GitHub Actions for automated PyPI publishing [#6](http://github.com/UAL-RE/redata-commons/issues/2)
    
 <!-- TEMPLATE
-## [vXX.YY.ZZ](https://github.com/UAL-ODIS/redata-commons/tree/vXX.YY.ZZ) (YYYY-MM-DD)
+## [vXX.YY.ZZ](https://github.com/UAL-RE/redata-commons/tree/vXX.YY.ZZ) (YYYY-MM-DD)
 
 **Implemented enhancements:**
- - `______` [#XX](http://github.com/UAL-ODIS/redata-commons/pull/XX)
+ - `______` [#XX](http://github.com/UAL-RE/redata-commons/pull/XX)
 
 **Fixed bugs:**
- - `______` [#XX](http://github.com/UAL-ODIS/redata-commons/issues/XX)
+ - `______` [#XX](http://github.com/UAL-RE/redata-commons/issues/XX)
 
 **Closed issues:**
- - `______` [#XX](http://github.com/UAL-ODIS/redata-commons/issues/XX)
+ - `______` [#XX](http://github.com/UAL-RE/redata-commons/issues/XX)
 
 **Merged pull requests:**
- - `______` [#XX](http://github.com/UAL-ODIS/redata-commons/pull/XX)
+ - `______` [#XX](http://github.com/UAL-RE/redata-commons/pull/XX)
 
 -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Office of Digital Innovation and Stewardship (University of Arizona Libraries)
+Copyright (c) 2021 The University of Arizona Libraries, Research Engagement
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redata-commons
 
-[![GitHub Actions Sphinx build status](https://img.shields.io/github/workflow/status/UAL-ODIS/redata-commons/Sphinx%20Docs%20Check?label=sphinx&color=blue)](https://github.com/UAL-ODIS/redata-commons/actions?query=workflow%3A%22Sphinx+Docs+Check%22)
+[![GitHub Actions Sphinx build status](https://img.shields.io/github/workflow/status/UAL-RE/redata-commons/Sphinx%20Docs%20Check?label=sphinx&color=blue)](https://github.com/UAL-RE/redata-commons/actions?query=workflow%3A%22Sphinx+Docs+Check%22)
 [![RTDs build status](https://readthedocs.org/projects/redata-commons/badge/?version=latest&style=flat)](https://redata-commons.readthedocs.io/en/latest/)
 
 This repository contains commonly used codes by ReDATA software. For our documentation, please click on the links below or visit [Read the Docs](https://redata-commons.readthedocs.io/en/latest/) directly.

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -9,4 +9,4 @@ See also the list of :repo:`contributors <contributors>` who participated in thi
 
 .. _@astrochun: http://www.github.com/astrochun
 .. _University of Arizona Libraries: https://github.com/ualibraries
-.. _Office of Digital Innovation and Stewardship: https://github.com/UAL-ODIS
+.. _Office of Digital Innovation and Stewardship: https://github.com/UAL-RE

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -2,11 +2,10 @@ Authors
 -------
 
 -  Chun Ly, Ph.D. (`@astrochun`_) -
-   `University of Arizona Libraries`_,
-   `Office of Digital Innovation and Stewardship`_
+   `University of Arizona Libraries`_, `Research Engagement`_
 
 See also the list of :repo:`contributors <contributors>` who participated in this project.
 
 .. _@astrochun: http://www.github.com/astrochun
 .. _University of Arizona Libraries: https://github.com/ualibraries
-.. _Office of Digital Innovation and Stewardship: https://github.com/UAL-RE
+.. _Research Engagement: https://github.com/UAL-RE

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ html_static_path = ['_static']
 
 
 # -- External links for repeated use:
-repo_link = 'https://github.com/UAL-ODIS/redata-commons'
+repo_link = 'https://github.com/UAL-RE/redata-commons'
 extlinks = {
     'repo': (f"{repo_link}/%s", None),
     'repo-main-file': (f"{repo_link}/blob/main/%s", None),

--- a/docs/source/execution.rst
+++ b/docs/source/execution.rst
@@ -158,4 +158,4 @@ in logs:
    df = pd.read_csv('data.csv')  # This is a dummy filename
    logger.pandas_write_buffer(df, log_filename)
 
-.. _`ReQUIAM`: https://github.com/UAL-ODIS/ReQUIAM
+.. _`ReQUIAM`: https://github.com/UAL-RE/ReQUIAM

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,5 +11,5 @@ From :repo:`source <>`:
 
 ::
 
-   (venv) $ git clone git@github.com:UAL-ODIS/redata-commons.git
+   (venv) $ git clone git@github.com:UAL-RE/redata-commons.git
    (venv) $ python setup.py install

--- a/redata/__init__.py
+++ b/redata/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 from . import commons

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='redata',
-    version='0.4.1',
+    version='0.4.2',
     packages=find_namespace_packages(),
     url='https://github.com/UAL-RE/redata-commons/',
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ setup(
     name='redata',
     version='0.4.1',
     packages=find_namespace_packages(),
-    url='https://github.com/UAL-ODIS/redata-commons/',
+    url='https://github.com/UAL-RE/redata-commons/',
     project_urls={
-        'Source': 'https://github.com/UAL-ODIS/redata-commons/',
-        'Tracker': 'https://github.com/UAL-ODIS/redata-commons/issues',
+        'Source': 'https://github.com/UAL-RE/redata-commons/',
+        'Tracker': 'https://github.com/UAL-RE/redata-commons/issues',
     },
     license='MIT License',
     author='Chun Ly',

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -11,7 +11,7 @@ log_dir = ''
 logfile = f'testlog.{today.strftime("%Y-%m-%d")}.log'
 
 # CSV url
-csv_url_prefix = "https://raw.githubusercontent.com/UAL-ODIS/ReQUIAM_csv"
+csv_url_prefix = "https://raw.githubusercontent.com/UAL-RE/ReQUIAM_csv"
 csv_version    = "master"
 csv_filename   = "requiam_csv/data/research_themes.csv"
 csv_url        = f"{csv_url_prefix}/{csv_version}/{csv_filename}"


### PR DESCRIPTION
Commit history:
- Org rename [ci skip]
- Org rename [ci skip]
- Bump version: v0.4.1 -> v0.4.2
