### PR TITLE
Issue 23. upgrade to Python 3.9

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install PyPI dependencies
       run: |
         python -m pip install --user --upgrade setuptools wheel

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'docs only')"
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.2.3
-tabulate==0.8.3
+pandas==1.4.3
+tabulate==0.8.10
 requests==2.25.1
 

--- a/setup.py
+++ b/setup.py
@@ -16,17 +16,16 @@ setup(
         'Tracker': 'https://github.com/UAL-RE/redata-commons/issues',
     },
     license='MIT License',
-    author='Chun Ly',
-    author_email='astro.chun@gmail.com',
+    author='Yan Han',
+    author_email='yhan818@gmail.com',
     description='Commons code used by ReDATA software',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=requirements,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9'
     ]


### PR DESCRIPTION
To make things clear, we separate two tasks: a) upgrade to Python 3.9, Pandas 1.4.3, and tabulate 0.8.10; b) upgrade to version 0.5.0. So after this issue closed, a separate PR will be created to upgrade to version "0.5.0". 