### PR TITLE
Fix: Use platform.uname instead of os.uname (Issue #37)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'docs only')"
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/redata/commons/logger.py
+++ b/redata/commons/logger.py
@@ -1,6 +1,7 @@
 import sys
 import io
-from os import path, uname, chmod, mkdir
+from os import path, chmod, mkdir
+from platform import uname
 
 from datetime import date
 import pandas as pd


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
Uses the more portable platform.uname() instead of the one in the os package.

<!-- Add any linked issue(s) -->
See #37 


*Testing (if applicable)*
The fix now allows Windows to fail more gracefully by not throwing an error immediately.  Still need to test on *nix to make sure the switch didn't break anything (though it should not have)